### PR TITLE
fix: properly mark expired cooldowns as inactive

### DIFF
--- a/src/main/java/com/iafenvoy/origins/data/power/HasCooldownPower.java
+++ b/src/main/java/com/iafenvoy/origins/data/power/HasCooldownPower.java
@@ -42,8 +42,8 @@ public abstract class HasCooldownPower extends Power implements HudRenderable {
     }
 
     @Override
-    public boolean isActive(OriginDataHolder holder) {
-        return super.isActive(holder) && getCooldownComponent(holder).getValue() > 0;
+    public boolean shouldRender(OriginDataHolder holder) {
+        return getCooldownComponent(holder).getValue() > 0;
     }
 
     protected CooldownComponent getCooldownComponent(OriginDataHolder holder) {

--- a/src/main/java/com/iafenvoy/origins/data/power/HasCooldownPower.java
+++ b/src/main/java/com/iafenvoy/origins/data/power/HasCooldownPower.java
@@ -41,6 +41,11 @@ public abstract class HasCooldownPower extends Power implements HudRenderable {
         return HudRenderable.clampProgress(this.getCooldownComponent(holder).getValue(), 0, this.cooldown.cooldown());
     }
 
+    @Override
+    public boolean isActive(OriginDataHolder holder) {
+        return super.isActive(holder) && getCooldownComponent(holder).getValue() > 0;
+    }
+
     protected CooldownComponent getCooldownComponent(OriginDataHolder holder) {
         return holder.getComponentFor(this, CooldownComponent.class).orElse(new CooldownComponent(1));
     }

--- a/src/main/java/com/iafenvoy/origins/data/power/HudRenderable.java
+++ b/src/main/java/com/iafenvoy/origins/data/power/HudRenderable.java
@@ -13,6 +13,10 @@ public interface HudRenderable {
 
     float getRenderPercentage(OriginDataHolder holder);
 
+    default boolean shouldRender(OriginDataHolder holder) {
+        return getPowerForHudRender().isActive(holder);
+    }
+
     static float clampProgress(float value, float min, float max) {
         return Mth.clamp((value - min) / (max - min), 0, 1);
     }

--- a/src/main/java/com/iafenvoy/origins/data/power/PowerReference.java
+++ b/src/main/java/com/iafenvoy/origins/data/power/PowerReference.java
@@ -33,6 +33,9 @@ public class PowerReference {
     public static Optional<PowerHolder> resolve(ResourceLocation rl, Registry<Power> registry) {
         if (rl == null) return Optional.empty();
 
+        Power direct = registry.get(rl);
+        if (direct != null) return Optional.of(new PowerHolder(rl, direct));
+
         Set<String> seen = new HashSet<>();
         String ns = rl.getNamespace();
         String path = rl.getPath();

--- a/src/main/java/com/iafenvoy/origins/data/power/builtin/action/ActiveSelfPower.java
+++ b/src/main/java/com/iafenvoy/origins/data/power/builtin/action/ActiveSelfPower.java
@@ -19,12 +19,13 @@ public class ActiveSelfPower extends HasCooldownPower implements Toggleable {
             BaseSettings.CODEC.forGetter(Power::getSettings),
             CooldownSettings.CODEC.forGetter(HasCooldownPower::getCooldown),
             KeySettings.CODEC.forGetter(ActiveSelfPower::getKey),
-            EntityAction.CODEC.fieldOf("entity_action").forGetter(ActiveSelfPower::getEntityAction)
-    ).apply(i, ActiveSelfPower::new));
+            EntityAction.CODEC.fieldOf("entity_action").forGetter(ActiveSelfPower::getEntityAction))
+            .apply(i, ActiveSelfPower::new));
     private final KeySettings key;
     private final EntityAction entityAction;
 
-    public ActiveSelfPower(BaseSettings settings, CooldownSettings cooldown, KeySettings key, EntityAction entityAction) {
+    public ActiveSelfPower(BaseSettings settings, CooldownSettings cooldown, KeySettings key,
+            EntityAction entityAction) {
         super(settings, cooldown);
         this.key = key;
         this.entityAction = entityAction;

--- a/src/main/java/com/iafenvoy/origins/data/power/builtin/action/AttackerActionWhenHitPower.java
+++ b/src/main/java/com/iafenvoy/origins/data/power/builtin/action/AttackerActionWhenHitPower.java
@@ -10,9 +10,11 @@ import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.world.entity.Entity;
 import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.event.entity.living.LivingDamageEvent;
 import org.jetbrains.annotations.NotNull;
 
+@EventBusSubscriber
 public class AttackerActionWhenHitPower extends HasCooldownPower {
     public static final MapCodec<AttackerActionWhenHitPower> CODEC = RecordCodecBuilder.mapCodec(i -> i.group(
             BaseSettings.CODEC.forGetter(Power::getSettings),

--- a/src/main/java/com/iafenvoy/origins/data/power/component/builtin/ActiveComponent.java
+++ b/src/main/java/com/iafenvoy/origins/data/power/component/builtin/ActiveComponent.java
@@ -23,11 +23,6 @@ public class ActiveComponent extends PowerComponent {
 
     public void tick(OriginDataHolder holder, Power power) {
         boolean result = power.getSettings().condition().test(holder.getEntity());
-        if (result) {
-            CooldownComponent cooldown = holder.getComponentFor(power, CooldownComponent.class).orElse(null);
-            if (cooldown != null)
-                result = cooldown.getValue() > 0;
-        }
         if (result ^ this.lastActive) {
             if (result)
                 power.active(holder);

--- a/src/main/java/com/iafenvoy/origins/data/power/component/builtin/ActiveComponent.java
+++ b/src/main/java/com/iafenvoy/origins/data/power/component/builtin/ActiveComponent.java
@@ -10,8 +10,7 @@ import org.jetbrains.annotations.NotNull;
 
 public class ActiveComponent extends PowerComponent {
     public static final MapCodec<ActiveComponent> CODEC = RecordCodecBuilder.mapCodec(i -> i.group(
-            Codec.BOOL.fieldOf("last_active").forGetter(ActiveComponent::isLastActive)
-    ).apply(i, ActiveComponent::new));
+            Codec.BOOL.fieldOf("last_active").forGetter(ActiveComponent::isLastActive)).apply(i, ActiveComponent::new));
     private boolean lastActive;
 
     public ActiveComponent(boolean lastActive) {
@@ -24,9 +23,16 @@ public class ActiveComponent extends PowerComponent {
 
     public void tick(OriginDataHolder holder, Power power) {
         boolean result = power.getSettings().condition().test(holder.getEntity());
+        if (result) {
+            CooldownComponent cooldown = holder.getComponentFor(power, CooldownComponent.class).orElse(null);
+            if (cooldown != null)
+                result = cooldown.getValue() > 0;
+        }
         if (result ^ this.lastActive) {
-            if (result) power.active(holder);
-            else power.inactive(holder);
+            if (result)
+                power.active(holder);
+            else
+                power.inactive(holder);
             this.lastActive = result;
             this.markDirty();
         }

--- a/src/main/java/com/iafenvoy/origins/data/power/component/builtin/ActiveComponent.java
+++ b/src/main/java/com/iafenvoy/origins/data/power/component/builtin/ActiveComponent.java
@@ -22,6 +22,7 @@ public class ActiveComponent extends PowerComponent {
     }
 
     public void tick(OriginDataHolder holder, Power power) {
+        if (holder.getEntity().level().isClientSide()) return;
         boolean result = power.getSettings().condition().test(holder.getEntity());
         if (result ^ this.lastActive) {
             if (result)

--- a/src/main/java/com/iafenvoy/origins/screen/overlay/HudRenderOverlay.java
+++ b/src/main/java/com/iafenvoy/origins/screen/overlay/HudRenderOverlay.java
@@ -48,7 +48,7 @@ public enum HudRenderOverlay implements LayeredDraw.Layer {
         for (HudRenderable h : holder.streamPowers(HudRenderable.class).filter(h -> h.getHudRenderData().isPresent()).sorted(Comparator.comparingInt(h -> h.getHudRenderData().get().order())).toList()) {
             Power power = h.getPowerForHudRender();
             HudRender render = h.getHudRenderData().orElse(null);
-            if (render == null || !render.shouldRenderInActive() && !power.isActive(holder) || !render.condition().test(player))
+            if (render == null || !render.shouldRenderInActive() && !h.shouldRender(holder) || !render.condition().test(player))
                 continue;
             //Rendering
             ResourceLocation currentLocation = render.spriteLocation();


### PR DESCRIPTION
Previously, HUD renders were only marked as inactive if their conditions did not pass, making powers with cooldowns always show regardless of cooldown value.