### PR TITLE
fix: cooldowns triggering prematurely

### DIFF
--- a/src/main/java/com/iafenvoy/origins/data/power/builtin/action/ActiveSelfPower.java
+++ b/src/main/java/com/iafenvoy/origins/data/power/builtin/action/ActiveSelfPower.java
@@ -52,8 +52,7 @@ public class ActiveSelfPower extends HasCooldownPower implements Toggleable {
 
     @Override
     public void toggle(@NotNull OriginDataHolder holder, String key) {
-        this.getCooldownComponent(holder).useIfReady(() -> {
-            if (this.key.match(key)) this.entityAction.execute(holder.getEntity());
-        });
+        if (this.key.match(key))
+            this.getCooldownComponent(holder).useIfReady(() -> this.entityAction.execute(holder.getEntity()));
     }
 }


### PR DESCRIPTION
Previously, cooldowns triggered automatically without checking if the key matched first.