### PR TITLE
fix: client/server only conditions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,7 +113,7 @@ configurations {
 }
 
 dependencies {
-//    implementation jarJar("maven.modrinth:integration:$integration_version")
+    implementation jarJar("maven.modrinth:integration:$integration_version")
     implementation jarJar("maven.modrinth:AdditionalEntityAttributes:6oJLT6m7")
     implementation jarJar("maven.modrinth:caelus:KsfI4QsR")
 

--- a/src/main/java/com/iafenvoy/origins/attachment/OriginDataHolder.java
+++ b/src/main/java/com/iafenvoy/origins/attachment/OriginDataHolder.java
@@ -6,6 +6,7 @@ import com.google.common.collect.Multimap;
 import com.iafenvoy.origins.Origins;
 import com.iafenvoy.origins.Proxies;
 import com.iafenvoy.origins.data.ItemPowersComponent;
+import com.iafenvoy.origins.data.condition.Side;
 import com.iafenvoy.origins.data.global_powers.GlobalPowersRegistries;
 import com.iafenvoy.origins.data.layer.Layer;
 import com.iafenvoy.origins.data.layer.LayerRegistries;
@@ -218,7 +219,17 @@ public final class OriginDataHolder {
 
     //Only for toggle and hud render, which need to bypass active logic
     private <T> Stream<T> streamPowers(Class<T> clazz, Predicate<ResourceLocation> idChecker) {
-        Stream<T> results = this.getAllPowers().stream().filter(x -> idChecker.test(x.id())).map(PowerHolder::power).filter(power -> clazz.isAssignableFrom(power.getClass())).map(clazz::cast);
+        Stream<Power> powers = this.getAllPowers().stream().filter(x -> idChecker.test(x.id())).map(PowerHolder::power).filter(power -> clazz.isAssignableFrom(power.getClass()));
+        if (entity.level().isClientSide()) {
+            powers = powers.filter(power -> {
+                if (power.getSettings().condition() instanceof Side condition) {
+                    return !condition.server();
+                } else return true;
+            });
+        }
+
+        Stream<T> results = powers.map(clazz::cast);
+
         return Prioritized.class.isAssignableFrom(clazz) ? results.map(Prioritized.class::cast).sorted(Comparator.comparingInt(Prioritized::getPriority)).map(clazz::cast) : results;
     }
 

--- a/src/main/java/com/iafenvoy/origins/data/condition/EntityCondition.java
+++ b/src/main/java/com/iafenvoy/origins/data/condition/EntityCondition.java
@@ -9,7 +9,8 @@ import org.jetbrains.annotations.NotNull;
 import java.util.function.Function;
 
 public interface EntityCondition {
-    Codec<EntityCondition> CODEC = DefaultedCodec.registryDispatch(ConditionRegistries.ENTITY_CONDITION, EntityCondition::codec, Function.identity(), () -> AlwaysTrueCondition.INSTANCE);
+    Codec<EntityCondition> CODEC = DefaultedCodec.registryDispatch(ConditionRegistries.ENTITY_CONDITION,
+            EntityCondition::codec, Function.identity(), () -> AlwaysTrueCondition.INSTANCE);
 
     static MapCodec<EntityCondition> optionalCodec(String name) {
         return CODEC.optionalFieldOf(name, AlwaysTrueCondition.INSTANCE);
@@ -17,6 +18,10 @@ public interface EntityCondition {
 
     @NotNull
     MapCodec<? extends EntityCondition> codec();
+
+    default boolean serverSideOnly() {
+        return false;
+    }
 
     boolean test(@NotNull Entity entity);
 }

--- a/src/main/java/com/iafenvoy/origins/data/condition/EntityCondition.java
+++ b/src/main/java/com/iafenvoy/origins/data/condition/EntityCondition.java
@@ -19,9 +19,5 @@ public interface EntityCondition {
     @NotNull
     MapCodec<? extends EntityCondition> codec();
 
-    default boolean serverSideOnly() {
-        return false;
-    }
-
     boolean test(@NotNull Entity entity);
 }

--- a/src/main/java/com/iafenvoy/origins/data/condition/Side.java
+++ b/src/main/java/com/iafenvoy/origins/data/condition/Side.java
@@ -1,0 +1,21 @@
+package com.iafenvoy.origins.data.condition;
+
+import javax.annotation.Nullable;
+
+import net.neoforged.api.distmarker.Dist;
+
+public interface Side {
+
+    @Nullable
+    default Dist side() {
+        return null;
+    }
+
+    default boolean client() {
+        return this.side() == null || this.side() == Dist.CLIENT;
+    }
+
+    default boolean server() {
+        return this.side() == null || this.side() == Dist.DEDICATED_SERVER;
+    }
+}

--- a/src/main/java/com/iafenvoy/origins/data/condition/builtin/entity/ExposedToSunCondition.java
+++ b/src/main/java/com/iafenvoy/origins/data/condition/builtin/entity/ExposedToSunCondition.java
@@ -1,5 +1,6 @@
 package com.iafenvoy.origins.data.condition.builtin.entity;
 
+import com.iafenvoy.origins.Origins;
 import com.iafenvoy.origins.data.condition.EntityCondition;
 import com.iafenvoy.origins.util.math.Comparison;
 import com.mojang.serialization.MapCodec;
@@ -8,13 +9,20 @@ import org.jetbrains.annotations.NotNull;
 
 public enum ExposedToSunCondition implements EntityCondition {
     INSTANCE;
+
     public static final MapCodec<ExposedToSunCondition> CODEC = MapCodec.unit(INSTANCE);
-    private static final BrightnessCondition BRIGHTNESS = new BrightnessCondition(new Comparison(Comparison.CompareOperation.GREATER_THAN, 0.5F));
+    private static final BrightnessCondition BRIGHTNESS = new BrightnessCondition(
+            new Comparison(Comparison.CompareOperation.GREATER_THAN, 0.5F));
     private static final ExposedToSkyCondition EXPOSED_TO_SKY = ExposedToSkyCondition.INSTANCE;
 
     @Override
     public @NotNull MapCodec<? extends EntityCondition> codec() {
         return CODEC;
+    }
+
+    @Override
+    public boolean serverSideOnly() {
+        return true;
     }
 
     @Override

--- a/src/main/java/com/iafenvoy/origins/data/condition/builtin/entity/ExposedToSunCondition.java
+++ b/src/main/java/com/iafenvoy/origins/data/condition/builtin/entity/ExposedToSunCondition.java
@@ -1,13 +1,15 @@
 package com.iafenvoy.origins.data.condition.builtin.entity;
 
-import com.iafenvoy.origins.Origins;
 import com.iafenvoy.origins.data.condition.EntityCondition;
+import com.iafenvoy.origins.data.condition.Side;
 import com.iafenvoy.origins.util.math.Comparison;
 import com.mojang.serialization.MapCodec;
 import net.minecraft.world.entity.Entity;
+import net.neoforged.api.distmarker.Dist;
+
 import org.jetbrains.annotations.NotNull;
 
-public enum ExposedToSunCondition implements EntityCondition {
+public enum ExposedToSunCondition implements EntityCondition, Side {
     INSTANCE;
 
     public static final MapCodec<ExposedToSunCondition> CODEC = MapCodec.unit(INSTANCE);
@@ -21,8 +23,8 @@ public enum ExposedToSunCondition implements EntityCondition {
     }
 
     @Override
-    public boolean serverSideOnly() {
-        return true;
+    public Dist side() {
+        return Dist.DEDICATED_SERVER;
     }
 
     @Override

--- a/src/main/java/com/iafenvoy/origins/data/power/component/builtin/ActiveComponent.java
+++ b/src/main/java/com/iafenvoy/origins/data/power/component/builtin/ActiveComponent.java
@@ -1,6 +1,7 @@
 package com.iafenvoy.origins.data.power.component.builtin;
 
 import com.iafenvoy.origins.attachment.OriginDataHolder;
+import com.iafenvoy.origins.data.condition.EntityCondition;
 import com.iafenvoy.origins.data.power.Power;
 import com.iafenvoy.origins.data.power.component.PowerComponent;
 import com.mojang.serialization.Codec;
@@ -9,8 +10,9 @@ import com.mojang.serialization.codecs.RecordCodecBuilder;
 import org.jetbrains.annotations.NotNull;
 
 public class ActiveComponent extends PowerComponent {
-    public static final MapCodec<ActiveComponent> CODEC = RecordCodecBuilder.mapCodec(i -> i.group(
-            Codec.BOOL.fieldOf("last_active").forGetter(ActiveComponent::isLastActive)).apply(i, ActiveComponent::new));
+    public static final MapCodec<ActiveComponent> CODEC = RecordCodecBuilder
+            .mapCodec(i -> i.group(Codec.BOOL.fieldOf("last_active").forGetter(ActiveComponent::isLastActive)).apply(i,
+                    ActiveComponent::new));
     private boolean lastActive;
 
     public ActiveComponent(boolean lastActive) {
@@ -22,8 +24,11 @@ public class ActiveComponent extends PowerComponent {
     }
 
     public void tick(OriginDataHolder holder, Power power) {
-        if (holder.getEntity().level().isClientSide()) return;
-        boolean result = power.getSettings().condition().test(holder.getEntity());
+        EntityCondition condition = power.getSettings().condition();
+        if (condition.serverSideOnly() && holder.getEntity().level().isClientSide())
+            return;
+
+        boolean result = condition.test(holder.getEntity());
         if (result ^ this.lastActive) {
             if (result)
                 power.active(holder);

--- a/src/main/java/com/iafenvoy/origins/data/power/component/builtin/ActiveComponent.java
+++ b/src/main/java/com/iafenvoy/origins/data/power/component/builtin/ActiveComponent.java
@@ -1,7 +1,6 @@
 package com.iafenvoy.origins.data.power.component.builtin;
 
 import com.iafenvoy.origins.attachment.OriginDataHolder;
-import com.iafenvoy.origins.data.condition.EntityCondition;
 import com.iafenvoy.origins.data.power.Power;
 import com.iafenvoy.origins.data.power.component.PowerComponent;
 import com.mojang.serialization.Codec;
@@ -24,11 +23,7 @@ public class ActiveComponent extends PowerComponent {
     }
 
     public void tick(OriginDataHolder holder, Power power) {
-        EntityCondition condition = power.getSettings().condition();
-        if (condition.serverSideOnly() && holder.getEntity().level().isClientSide())
-            return;
-
-        boolean result = condition.test(holder.getEntity());
+        boolean result = power.getSettings().condition().test(holder.getEntity());
         if (result ^ this.lastActive) {
             if (result)
                 power.active(holder);


### PR DESCRIPTION
Some conditions need to be evaluated on both client and server and some need to be evaluated on only the server. Added in support for this in EntityCondition interface.

This fixes climbing