### PR TITLE
fix: executeCommand running with 0 perm level, command spam

### DIFF
--- a/src/main/java/com/iafenvoy/origins/data/_common/helper/CommandHelper.java
+++ b/src/main/java/com/iafenvoy/origins/data/_common/helper/CommandHelper.java
@@ -13,6 +13,8 @@ import net.minecraft.world.phys.Vec3;
 
 import java.util.function.Consumer;
 
+import com.iafenvoy.origins.config.OriginsConfig;
+
 public interface CommandHelper {
     default void executeCommand(Level level, Consumer<CommandSourceStack> consumer, String command) {
         if (level instanceof ServerLevel serverLevel) this.executeCommand(serverLevel.getServer(), consumer, command);
@@ -25,12 +27,23 @@ public interface CommandHelper {
     }
 
     default void executeCommand(Entity entity, String command) {
-        this.executeCommand(entity, entity.position(), command);
+        this.executeCommand(entity, entity.position(), command, false);
+    }
+
+    default void executeCommand(Entity entity, String command, boolean silent) {
+        this.executeCommand(entity, entity.position(), command, silent);
     }
 
     default void executeCommand(Entity entity, Vec3 pos, String command) {
-        if (entity.level() instanceof ServerLevel level)
-            this.executeCommand(entity.createCommandSourceStack().withPosition(pos), level.getServer(), command);
+        this.executeCommand(entity, pos, command, false);
+    }
+
+    default void executeCommand(Entity entity, Vec3 pos, String command, boolean silent) {
+        if (entity.level() instanceof ServerLevel level) {
+            CommandSourceStack stack = new CommandSourceStack(entity, pos, entity.getRotationVector(), level, OriginsConfig.INSTANCE.general.permissionLevel.getValue(), entity.getName().getString(), entity.getDisplayName(), entity.level().getServer(), entity);
+            if (silent) stack = stack.withSuppressedOutput();
+            this.executeCommand(stack, level.getServer(), command);
+        }
     }
 
     default void executeCommand(CommandSourceStack stack, MinecraftServer server, String command) {

--- a/src/main/java/com/iafenvoy/origins/data/action/builtin/entity/ExecuteCommandAction.java
+++ b/src/main/java/com/iafenvoy/origins/data/action/builtin/entity/ExecuteCommandAction.java
@@ -20,6 +20,6 @@ public record ExecuteCommandAction(String command) implements EntityAction, Comm
 
     @Override
     public void execute(@NotNull Entity source) {
-        this.executeCommand(source, this.command);
+        this.executeCommand(source, this.command, true);
     }
 }


### PR DESCRIPTION
Using tick update execute command action spammed the chat log.

Also, using things like pehkui didn't work except for OPs because of permission level being hardcoded to 0