### PR TITLE
fix: right click bind, multiple binds, toggleable power fixes

### DIFF
--- a/src/main/java/com/iafenvoy/origins/attachment/OriginDataHolder.java
+++ b/src/main/java/com/iafenvoy/origins/attachment/OriginDataHolder.java
@@ -99,11 +99,7 @@ public final class OriginDataHolder {
                 List<KeyMapping> keys = KeyMapping.ALL.entrySet().stream()
                         .filter(e -> Objects.equals(toggleable.getKey().key(), e.getValue().getName()))
                         .map(Map.Entry::getValue).toList();
-                for (KeyMapping key : keys) {
-                    Origins.LOGGER.debug("Registering toggle key {} for power {} of entity {}", key.getName(),
-                            powerHolder.id(), this.entity);
-                    OriginsKeyMappings.ACTIVATE_KEYS.add(key);
-                }
+                OriginsKeyMappings.ACTIVATE_KEYS.addAll(keys);
             }
         }
     }

--- a/src/main/java/com/iafenvoy/origins/attachment/OriginDataHolder.java
+++ b/src/main/java/com/iafenvoy/origins/attachment/OriginDataHolder.java
@@ -92,16 +92,16 @@ public final class OriginDataHolder {
 
     private void registerToggleKeysFromExistingPowers() {
         OriginsKeyMappings.ACTIVATE_KEYS.clear();
-        OriginsKeyMappings.ACTIVATE_KEYS.add(OriginsKeyMappings.PRIMARY_ACTIVE);
-        OriginsKeyMappings.ACTIVATE_KEYS.add(OriginsKeyMappings.SECONDARY_ACTIVE);
 
         for (PowerHolder powerHolder : this.getAllPowers()) {
             Power power = powerHolder.power();
             if (power instanceof Toggleable toggleable) {
-                KeyMapping key = KeyMapping.ALL.entrySet().stream()
-                        .filter(e -> Objects.equals(toggleable.getKey().key(), e.getValue().getName())).findFirst()
-                        .map(Map.Entry::getValue).orElse(null);
-                if (key != null && !OriginsKeyMappings.ACTIVATE_KEYS.contains(key)) {
+                List<KeyMapping> keys = KeyMapping.ALL.entrySet().stream()
+                        .filter(e -> Objects.equals(toggleable.getKey().key(), e.getValue().getName()))
+                        .map(Map.Entry::getValue).toList();
+                for (KeyMapping key : keys) {
+                    Origins.LOGGER.debug("Registering toggle key {} for power {} of entity {}", key.getName(),
+                            powerHolder.id(), this.entity);
                     OriginsKeyMappings.ACTIVATE_KEYS.add(key);
                 }
             }

--- a/src/main/java/com/iafenvoy/origins/attachment/PowerHelper.java
+++ b/src/main/java/com/iafenvoy/origins/attachment/PowerHelper.java
@@ -3,6 +3,7 @@ package com.iafenvoy.origins.attachment;
 import com.iafenvoy.origins.data._common.helper.ModifierPowerHelper;
 import com.iafenvoy.origins.data.power.Power;
 import com.iafenvoy.origins.data.power.Toggleable;
+import com.iafenvoy.origins.data.power.builtin.regular.TogglePower;
 
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -38,9 +39,13 @@ public record PowerHelper(OriginDataHolder holder) {
 
     public void toggle(String key) {
         this.holder.streamPowers(Toggleable.class).filter(x -> {
-            if (x instanceof Power p)
+            //because of TogglePower isActive override
+            if (x instanceof TogglePower)
+                return true;
+            else if (x instanceof Power p)
                 return p.isActive(this.holder);
-            return false;
+            else
+                return false;
         }).forEach(x -> x.toggle(this.holder, key));
     }
 }

--- a/src/main/java/com/iafenvoy/origins/attachment/PowerHelper.java
+++ b/src/main/java/com/iafenvoy/origins/attachment/PowerHelper.java
@@ -37,6 +37,10 @@ public record PowerHelper(OriginDataHolder holder) {
     }
 
     public void toggle(String key) {
-        this.holder.streamPowers(Toggleable.class).forEach(x -> x.toggle(this.holder, key));
+        this.holder.streamPowers(Toggleable.class).filter(x -> {
+            if (x instanceof Power p)
+                return p.isActive(this.holder);
+            return false;
+        }).forEach(x -> x.toggle(this.holder, key));
     }
 }

--- a/src/main/java/com/iafenvoy/origins/attachment/PowerHelper.java
+++ b/src/main/java/com/iafenvoy/origins/attachment/PowerHelper.java
@@ -3,7 +3,6 @@ package com.iafenvoy.origins.attachment;
 import com.iafenvoy.origins.data._common.helper.ModifierPowerHelper;
 import com.iafenvoy.origins.data.power.Power;
 import com.iafenvoy.origins.data.power.Toggleable;
-import com.iafenvoy.origins.data.power.builtin.regular.TogglePower;
 
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -38,14 +37,6 @@ public record PowerHelper(OriginDataHolder holder) {
     }
 
     public void toggle(String key) {
-        this.holder.streamPowers(Toggleable.class).filter(x -> {
-            //because of TogglePower isActive override
-            if (x instanceof TogglePower)
-                return true;
-            else if (x instanceof Power p)
-                return p.isActive(this.holder);
-            else
-                return false;
-        }).forEach(x -> x.toggle(this.holder, key));
+        this.holder.streamPowers(Toggleable.class).forEach(x -> x.toggle(this.holder, key));
     }
 }

--- a/src/main/java/com/iafenvoy/origins/data/power/builtin/action/ActiveSelfPower.java
+++ b/src/main/java/com/iafenvoy/origins/data/power/builtin/action/ActiveSelfPower.java
@@ -52,7 +52,7 @@ public class ActiveSelfPower extends HasCooldownPower implements Toggleable {
 
     @Override
     public void toggle(@NotNull OriginDataHolder holder, String key) {
-        if (this.key.match(key))
+        if (this.key.match(key) && this.isActive(holder))
             this.getCooldownComponent(holder).useIfReady(() -> this.entityAction.execute(holder.getEntity()));
     }
 }

--- a/src/main/java/com/iafenvoy/origins/data/power/builtin/regular/FireProjectilePower.java
+++ b/src/main/java/com/iafenvoy/origins/data/power/builtin/regular/FireProjectilePower.java
@@ -127,7 +127,7 @@ public class FireProjectilePower extends HasCooldownPower implements Toggleable 
 
     @Override
     public void toggle(@NotNull OriginDataHolder holder, String key) {
-        if (!this.key.match(key)) return;
+        if (!this.key.match(key) || !this.isActive(holder)) return;
         Entity entity = holder.getEntity();
         this.getCooldownComponent(holder).useIfReady(() -> {
             if (this.interval <= 0) Timeout.create(this.startDelay, () -> {

--- a/src/main/java/com/iafenvoy/origins/data/power/builtin/regular/FireProjectilePower.java
+++ b/src/main/java/com/iafenvoy/origins/data/power/builtin/regular/FireProjectilePower.java
@@ -127,6 +127,7 @@ public class FireProjectilePower extends HasCooldownPower implements Toggleable 
 
     @Override
     public void toggle(@NotNull OriginDataHolder holder, String key) {
+        if (!this.key.match(key)) return;
         Entity entity = holder.getEntity();
         this.getCooldownComponent(holder).useIfReady(() -> {
             if (this.interval <= 0) Timeout.create(this.startDelay, () -> {

--- a/src/main/java/com/iafenvoy/origins/data/power/builtin/regular/InventoryPower.java
+++ b/src/main/java/com/iafenvoy/origins/data/power/builtin/regular/InventoryPower.java
@@ -108,7 +108,7 @@ public class InventoryPower extends Power implements Toggleable, MenuProvider {
 
     @Override
     public void toggle(@NotNull OriginDataHolder holder, String key) {
-        if (holder.getEntity() instanceof Player player && Objects.equals(this.key.key(), key))
+        if (holder.getEntity() instanceof Player player && this.key.match(key))
             player.openMenu(this);
     }
 

--- a/src/main/java/com/iafenvoy/origins/data/power/builtin/regular/InventoryPower.java
+++ b/src/main/java/com/iafenvoy/origins/data/power/builtin/regular/InventoryPower.java
@@ -108,7 +108,7 @@ public class InventoryPower extends Power implements Toggleable, MenuProvider {
 
     @Override
     public void toggle(@NotNull OriginDataHolder holder, String key) {
-        if (holder.getEntity() instanceof Player player && this.key.match(key))
+        if (holder.getEntity() instanceof Player player && this.key.match(key) && this.isActive(holder))
             player.openMenu(this);
     }
 

--- a/src/main/java/com/iafenvoy/origins/data/power/builtin/regular/LaunchPower.java
+++ b/src/main/java/com/iafenvoy/origins/data/power/builtin/regular/LaunchPower.java
@@ -66,8 +66,8 @@ public class LaunchPower extends HasCooldownPower implements Toggleable {
 
     @Override
     public void toggle(@NotNull OriginDataHolder holder, String key) {
+        if (!this.key.match(key)) return;
         this.getCooldownComponent(holder).useIfReady(() -> {
-            if (this.key.match(key)) {
                 Entity entity = holder.getEntity();
                 if (entity.level() instanceof ServerLevel serverLevel) {
                     entity.push(0, this.speed, 0);
@@ -76,7 +76,6 @@ public class LaunchPower extends HasCooldownPower implements Toggleable {
                     for (int i = 0; i < 4; ++i)
                         serverLevel.sendParticles(ParticleTypes.CLOUD, entity.getX(), entity.getRandomY(), entity.getZ(), 8, entity.level().random.nextGaussian(), 0.0D, entity.level().random.nextGaussian(), 0.5);
                 }
-            }
         });
     }
 }

--- a/src/main/java/com/iafenvoy/origins/data/power/builtin/regular/LaunchPower.java
+++ b/src/main/java/com/iafenvoy/origins/data/power/builtin/regular/LaunchPower.java
@@ -66,7 +66,7 @@ public class LaunchPower extends HasCooldownPower implements Toggleable {
 
     @Override
     public void toggle(@NotNull OriginDataHolder holder, String key) {
-        if (!this.key.match(key)) return;
+        if (!this.key.match(key) || !this.isActive(holder)) return;
         this.getCooldownComponent(holder).useIfReady(() -> {
                 Entity entity = holder.getEntity();
                 if (entity.level() instanceof ServerLevel serverLevel) {

--- a/src/main/java/com/iafenvoy/origins/mixin/GameRendererMixin.java
+++ b/src/main/java/com/iafenvoy/origins/mixin/GameRendererMixin.java
@@ -6,7 +6,6 @@ import com.iafenvoy.origins.data.power.builtin.regular.NightVisionPower;
 import com.iafenvoy.origins.data.power.builtin.regular.PhasingPower;
 import com.iafenvoy.origins.data.power.builtin.regular.ShaderPower;
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
-import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import com.llamalad7.mixinextras.sugar.Local;
 import net.minecraft.client.Camera;
 import net.minecraft.client.DeltaTracker;
@@ -67,11 +66,6 @@ public abstract class GameRendererMixin {
 
     @Shadow
     public abstract void loadEffect(ResourceLocation resourceLocation);
-
-    @Inject(method = "getNightVisionScale", at = @At("HEAD"), cancellable = true)
-    private static void nightVisionPatch(LivingEntity livingEntity, float nanoTime, CallbackInfoReturnable<Float> cir) {
-        if (!livingEntity.hasEffect(MobEffects.NIGHT_VISION)) cir.setReturnValue(0F);
-    }
 
     @ModifyExpressionValue(method = "getFov", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/Camera;getFluidInCamera()Lnet/minecraft/world/level/material/FogType;"))
     private FogType modifySubmersionType(FogType original, Camera camera) {
@@ -169,8 +163,9 @@ public abstract class GameRendererMixin {
             ci.cancel();
     }
 
-    @ModifyReturnValue(method = "getNightVisionScale", at = @At("RETURN"))
-    private static float updateNightVisionScale(float original, LivingEntity living, float tickDelta) {
-        return !living.hasEffect(MobEffects.NIGHT_VISION) ? OriginDataHolder.get(living).streamActivePowers(NightVisionPower.class).map(NightVisionPower::getStrength).max(Float::compareTo).orElse(original) : original;
+    @Inject(method = "getNightVisionScale", at = @At("HEAD"), cancellable = true)
+    private static void updateNightVisionScale(LivingEntity living, float tickDelta, CallbackInfoReturnable<Float> cir) {
+        if (!living.hasEffect(MobEffects.NIGHT_VISION) && OriginDataHolder.get(living).hasActivePower(NightVisionPower.class))
+            cir.setReturnValue(OriginDataHolder.get(living).streamActivePowers(NightVisionPower.class).map(NightVisionPower::getStrength).max(Float::compareTo).orElse(1F));
     }
 }

--- a/src/main/java/com/iafenvoy/origins/registry/OriginsKeyMappings.java
+++ b/src/main/java/com/iafenvoy/origins/registry/OriginsKeyMappings.java
@@ -34,7 +34,7 @@ public final class OriginsKeyMappings {
     }
 
     @SubscribeEvent
-    public static void clientTick(ClientTickEvent.Post event) {
+    public static void clientTick(ClientTickEvent.Pre event) {
         if (VIEW_ORIGIN.consumeClick()) Minecraft.getInstance().setScreen(new ViewOriginScreen());
         for (KeyMapping key : ACTIVATE_KEYS)
             if (key.consumeClick()) PacketDistributor.sendToServer(new PowerToggleC2SPayload(key.getName()));


### PR DESCRIPTION
- Added support for multiple powers bound to 1 key (found this while trying to make 2 powers with right click)
- Fixed toggleable powers ignoring conditions (didn't check isActive)
- Fixed a few toggle powers that triggered cooldown prematurely / didn't check key at all
- Moved Keybind loop to pre client tick because vanilla minecraft was consuming right click events before they could be read (made right click powers among a couple other impossible)